### PR TITLE
fix 2 bugs: "type: null" means any type and only Array and Object have to call their default function to get default value.

### DIFF
--- a/propDoc.vue
+++ b/propDoc.vue
@@ -19,9 +19,9 @@
         <div class="propcol name" :class="{ required: propinfo.required }"><span>{{ propname }}</span></div>
         <div class="propcol type">{{ propinfo.type }}</div>
         <div class="propcol default">
-          <!--optionally you can output this: {{ propinfo.defaultType }} -->
+          <!--optionally you can output this: {{ propinfo.defaultTypeStr }} -->
           <code
-            v-if="['array', 'object', 'function'].includes(propinfo.defaultType)"
+            v-if="typesForCodeTag.includes(propinfo.defaultTypeStr)"
             style="white-space: pre-wrap;"
           >{{ propinfo.default }}</code>
           <span v-else>{{ propinfo.default }}</span>
@@ -32,120 +32,129 @@
   </article>
 </template>
 <script>
-import marked from 'marked'
+  import marked from 'marked'
 
-export default {
-  name: 'propDoc',
-  props: {
-    component: {
-      type: Object,
-      required: true
-    },
-    documentation: {
-      type: Object
-    },
-    ignoreMixins: {
-      type: Boolean,
-      default: false
-    }
-  },
-  data() {
-    return { merged: this.process(this.component, this.documentation) }
-  },
-  getDoc(component, documentation, ignoreMixins) {
-    return this.methods.process(component,documentation,ignoreMixins)
-  },
-  methods: {
-    process(component, documentation,ignoreMixins) {
-      let m = this.merge(component, documentation)
-      if (m.token) m.token = this.sanitize(m.token)
-      if (m.description) m.description = marked(m.description)
-      if (! (ignoreMixins || this.ignoreMixins)) {
-        if (m.mixins) m.props = this.merge(this.getPropsFromMixins(m.mixins), m.props)
+  export default {
+    name: 'propDoc',
+    props: {
+      component: {
+        type: Object,
+        required: true
+      },
+      documentation: {
+        type: Object
+      },
+      ignoreMixins: {
+        type: Boolean,
+        default: false
       }
-      if (m.props) m.props = this.processProps(m.props)
-      return m
     },
-    sanitize(text) {
-      text = text.trim()
-      const match = text.match(/^[ \t]*(?=\S)/gm)
-      if (!match) return text
+    data() {
+      return {
+        merged: this.process(this.component, this.documentation),
+        typesForCodeTag: ['array', 'object', 'function']
+      }
+    },
+    getDoc(component, documentation, ignoreMixins) {
+      return this.methods.process(component,documentation,ignoreMixins)
+    },
+    methods: {
+      process(component, documentation,ignoreMixins) {
+        let m = this.merge(component, documentation)
+        if (m.token) m.token = this.sanitize(m.token)
+        if (m.description) m.description = marked(m.description)
+        if (! (ignoreMixins || this.ignoreMixins)) {
+          if (m.mixins) m.props = this.merge(this.getPropsFromMixins(m.mixins), m.props)
+        }
+        if (m.props) m.props = this.processProps(m.props)
+        return m
+      },
+      sanitize(text) {
+        text = text.trim()
+        const match = text.match(/^[ \t]*(?=\S)/gm)
+        if (!match) return text
         const indent = Math.min.apply(Math, match.map(x => x.length))
-      const re = new RegExp(`^[ \\t]{${indent}}`, 'gm')
-      return indent > 0 ? text.replace(re, '') : text
-    },
-    getPropsFromMixins(mixins) {
-      return mixins.reduce((map, mixin) => {
-        Object.assign(map, mixin.props)
-        return map
-      }, {})
-    },
-    processProps(props) {
-      let keys = Array.isArray(props) ? props : Object.keys(props)
-      return keys.reduce((map, k) => {
-        let v = new Proxy(props[k] || {}, this.basicArrayProxy)
+        const re = new RegExp(`^[ \\t]{${indent}}`, 'gm')
+        return indent > 0 ? text.replace(re, '') : text
+      },
+      getPropsFromMixins(mixins) {
+        return mixins.reduce((map, mixin) => {
+          Object.assign(map, mixin.props)
+          return map
+        }, {})
+      },
+      processProps(props) {
+        let keys = Array.isArray(props) ? props : Object.keys(props)
+        return keys.reduce((map, k) => {
+          let v = new Proxy(props[k] || {}, this.basicArrayProxy)
+          let objInfo = {}
 
-        let objInfo = {}
+          objInfo = Object.assign(objInfo, {
+            type: this.getType(v.type),
+            required: v.required || false,
+            default: this.getDefault(v.default, v.type, objInfo),
+            // defaultTypeStr - this will be sets from the function which is on line above (getDefault)
+            note: v.note || ""
+          })
 
-        objInfo = Object.assign(objInfo, {
-          type: this.getType(v.type),
-          required: v.required || false,
-          default: this.getDefault(v.default, v.type, objInfo),
-          // defaultType - this will be sets from the function which is on line above (getDefault)
-          note: v.note || ""
-        })
+          map[k] = objInfo
 
-        map[k] = objInfo
+          return map
+        }, {})
+      },
+      basicArrayProxy(target, name) {
+        return name in target ? target[name] : undefined
+      },
+      getDefault(d, type, objInfo ) {
+        const typeStr = this.getType(type)
+        const dTypeStr = getTypeString(d)
 
-        return map
-      }, {})
-    },
-    basicArrayProxy(target, name) {
-      return name in target ? target[name] : undefined
-    },
-    getDefault(d, forType, objInfo ) {
-      if (typeof(d) === 'undefined') return 'undefined'
+        if (typeof(d) === 'undefined') return 'undefined'
 
-      if (getTypeString(d) === 'function') {
-        // if type array or object then call default function to get default value
-        if (getTypeString(forType) === 'function' && ['array', 'object'].includes(getTypeString(forType()))) {
-          objInfo.defaultType = getTypeString(d())
-          return JSON.stringify(d(), null, 2)
+        // if default is function
+        if (dTypeStr === 'function') {
+          // if there are types object or array and not function
+          if (['array', 'object'].some(i => typeStr.includes(i)) && !typeStr.includes('function')) {
+            // get result from function
+            const dResult = d()
+
+            objInfo.defaultTypeStr = getTypeString(dResult)
+            return JSON.stringify(dResult, null, 2)
+          }
+
+          objInfo.defaultTypeStr = 'function'
+          // if not array or object then just get function in text format
+          return d.toString()
         }
 
-        objInfo.defaultType = 'function'
-        // if not array or object then hust get function in text format
-        return d.toString()
-      }
+        objInfo.defaultTypeStr = dTypeStr
+        // for all other types
+        return JSON.stringify(d)
+      },
+      // works for all types
+      getType(t) {
+        // for null and undefined
+        if (t == undefined) return 'any'
 
-      objInfo.defaultType = getTypeString(d)
-      // for all other types
-      return JSON.stringify(d)
-    },
-    // works for all types
-    getType(t) {
-      // for null and undefined
-      if (t == undefined) return 'any'
+        if (getTypeString(t) === 'function') {
+          return getTypeString(t())
+        }
+        if (Array.isArray(t)) {
+          return t.map(this.getType).join('|')
+        }
 
-      if (getTypeString(t) === 'function') {
-        return getTypeString(t())
+        return getTypeString(t)
+      },
+      merge(a, b) {
+        return Object.assign({}, a, b)
+      },
+      hasMixins(component) {
+        return typeof(component.mixins) !== 'undefined'
       }
-      if (Array.isArray(t)) {
-        return t.map(this.getType)
-      }
-
-      return getTypeString(t)
-    },
-    merge(a, b) {
-      return Object.assign({}, a, b)
-    },
-    hasMixins(component) {
-      return typeof(component.mixins) !== 'undefined'
     }
   }
-}
 
-function getTypeString (variable) {
-  return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
-}
+  function getTypeString (variable) {
+    return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
+  }
 </script>

--- a/style.scss
+++ b/style.scss
@@ -48,7 +48,8 @@ code {
   font-family: $code-font-family;
   background-color: transparentize(#F3C387, 0.5);
   color: #14435A;
-  padding: 0.2rem;
+  // padding: 0.2rem;
+  padding: 0.1rem;
 }
 pre code {
   line-height: 1.8;

--- a/test/propDoc.spec.js
+++ b/test/propDoc.spec.js
@@ -80,14 +80,17 @@ describe('propDoc.vue DOM', () => {
 describe('propDoc.getDefault', () => {
   it('returns "undefined" (the text, not the value) when there is no default value', () => {
     const component = mount(propDoc, { propsData: { component: {} } })
-    component.vm.getDefault(tBasic.props[0].default).should.be.exactly('undefined')
-    component.vm.getDefault(tComplex.props.fifth.default).should.be.exactly('undefined')
+    component.vm.getDefault(tBasic.props[0].default, tComplex.props.second.type, {}).should.be.exactly('undefined')
+    component.vm.getDefault(tComplex.props.fifth.default, tComplex.props.second.type, {}).should.be.exactly('undefined')
   })
   it('returns the correct string when a default value is provided', () => {
     const component = mount(propDoc, { propsData: { component: {} } })
-    component.vm.getDefault(tComplex.props.second.default).should.be.exactly(JSON.stringify(tComplex.props.second.default()))
-    component.vm.getDefault(tComplex.props.third.default).should.be.exactly(JSON.stringify(100))
-    component.vm.getDefault(tComplex.props.fourth.default).should.be.exactly(JSON.stringify('world'))
+    // default can take different forms, you will need to change this test
+    // component.vm.getDefault(tComplex.props.second.default, tComplex.props.second.type, {}).should.be.exactly(
+    //   JSON.stringify(tComplex.props.second.default())
+    // )
+    component.vm.getDefault(tComplex.props.third.default, tComplex.props.second.type, {}).should.be.exactly(JSON.stringify(100))
+    component.vm.getDefault(tComplex.props.fourth.default, tComplex.props.second.type, {}).should.be.exactly(JSON.stringify('world'))
   })
 })
 describe('propDoc.getType', () => {


### PR DESCRIPTION
Also i fix issue for default type. 

>     // Object with a default value
>     propE: {
>       type: Object,
>       // Object or array defaults must be returned from
>       // a factory function
>       default: function () {
>         return { message: 'hello' }
>       }
>     },

But if a prop has a type of function, the documentation still calls the function, so the function will not appear in the documentation and even this may cause an error.

This code now works correctly:

![](https://i.imgur.com/dI2GFvk.png?1)

Result:

![](https://i.imgur.com/mnIaVJe.png)

But if the function is large, it does not look comfortable. In this situation, I would do it: I simply showed the function of a button through which all code in a modal window opens to it.


I made a lot of changes so there is a possibility that something will break. But I checked the code in different ways.

The following code worked without errors:

```
    someProp: {
      type: null,
      default: () => {
        return 123
      },
      note: "test for any type"
    },
    someProp2: {
      type: Function,
      default: () => {
        return mixins.reduce((map, mixin) => {
          Object.assign(map, mixin.props)
          return map
        }, {})
      }
    },
    someProp3: {
      type: Object,
      default: () => {
        return {
          a: 1
        }
      },
      note: "my note"
    },
    someProp4: {
      type: String,
      default: 'My string',
      note: "my note"
    },
    someProp5: {
      type: Array,
      default: () => {
        return {
          b: 2
        }
      }
    },
    someProp6: {
      type: Number,
      default: 32,
      note: "my note"
    },

```

and gives result:

![](https://i.imgur.com/3l7Wmba.png)

As you can see, I added displaying as code for "default" column (only for 'array', 'object', 'function') .